### PR TITLE
Add Vuetify context

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ Enable the plugin in your Project
 ```javascript
 import Vue from "vue";
 import confirmDialog from "vuetify-vuejs-confirmdialog";
-Vue.use(confirmDialog);
+Vue.use(confirmDialog, {
+  // assuming `vuetify` is a Vuetify instance created before
+  context: { vuetify },
+});
 
 // …
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,10 @@ let Plugin = function(Vue, globalOptions = {}) {
   this.Vue = Vue;
   this.mounted = false;
   this.$root = {};
+  this.context = {};
+  if (globalOptions.context) {
+    this.context = globalOptions.context;
+  }
 };
 
 Plugin.prototype.mountIfNotMounted = function() {
@@ -16,7 +20,7 @@ Plugin.prototype.mountIfNotMounted = function() {
     let ConfirmConstructor = this.Vue.extend(PromiseVuetifyConfirm);
     let node = document.createElement("div");
     document.querySelector("#app").appendChild(node);
-    return new ConfirmConstructor().$mount(node);
+    return new ConfirmConstructor(this.context).$mount(node);
   })();
 
   this.mounted = true;


### PR DESCRIPTION
Currently, errors appear when opening a dialog:
```
[Vue warn]: Error in callback for watcher "isActive": "TypeError: undefined is not an object (evaluating 'this.$vuetify.breakpoint.smAndDown')"

found in

---> <VDialog>
       <ConfirmDialog> at VuetifyConfirm.vue
         <Root>
```

Example: https://codesandbox.io/embed/condescending-ritchie-v7mt2?expanddevtools=1&fontsize=14&hidenavigation=1&theme=dark

This PR adds a `context` option to the plugin's constructor which can/should be used to provide the Vuetify instance on instantiation. That way, `$vuetify` is no longer `undefined`.